### PR TITLE
docs: Add English version of README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -17,6 +17,10 @@
   <img src="https://img.shields.io/badge/Chrome%20Extension-MV3-green.svg?logo=googlechrome" alt="Chrome Extension MV3">
 </p>
 
+<p align="center">
+  <a href="./README.md">中文</a> | <a href="./README.en.md">English</a>
+</p>
+
 **ContextDrop** is a browser extension focused on **AI assistant memory management**. It can:<br>
 
 💾 **Capture Sessions**: Automatically saves conversation records between you and AI assistants while you chat<br>

--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,110 @@
+<h1 align="center"><img src="icons/context-drop.svg" width="32" height="32" alt="ContextDrop">  ContextDrop: Seamlessly Transfer Your AI Memories Across Sessions & Platforms</h1>
+
+<p align="center"><b>AI forgets everything after a new session? Losing history when switching platforms? ContextDrop helps you transfer conversation memories across any session and any platform</b></p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Doubao-Supported-ff6a00" alt="Doubao Supported">
+  <img src="https://img.shields.io/badge/Yuanbao-Supported-00c853" alt="Yuanbao Supported">
+  <img src="https://img.shields.io/badge/Claude-Supported-d97757?logo=anthropic" alt="Claude Supported">
+  <img src="https://img.shields.io/badge/DeepSeek-Supported-4d6bfa" alt="DeepSeek Supported">
+  <img src="https://img.shields.io/badge/Gemini-Supported-4285f4?logo=google" alt="Gemini Supported">
+  <img src="https://img.shields.io/badge/ChatGPT-Supported-10a37f?logo=openai" alt="ChatGPT Supported">
+</p>
+
+<p align="center">
+  <a href="https://github.com/Jackie2049/ContextDrop/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
+  <img src="https://img.shields.io/badge/TypeScript-5.0-blue.svg?logo=typescript" alt="TypeScript">
+  <img src="https://img.shields.io/badge/Chrome%20Extension-MV3-green.svg?logo=googlechrome" alt="Chrome Extension MV3">
+</p>
+
+**ContextDrop** is a browser extension focused on **AI assistant memory management**. It can:<br>
+
+💾 **Capture Sessions**: Automatically saves conversation records between you and AI assistants while you chat<br>
+✏️ **Inject Memories**: On-demand injection of captured AI memories into the current session, with support for content editing<br>
+🌍 **Cross-Platform**: Supports cross-session and cross-platform operations, seamlessly transferring your AI memories — just like AirDrop<br>
+
+Data is stored locally, with support for export and import. Your privacy is safe and secure<br>
+Now compatible with Doubao, DeepSeek, ChatGPT, Gemini, Yuanbao, Kimi, Claude and other mainstream AI assistants<br>
+
+---
+
+## Feature Demo
+
+### ① Auto Capture Sessions — Just Chat, We'll Handle the Recording
+
+Turn on the "Auto Capture" switch, and ContextDrop will automatically capture session records and cache AI memories locally — no manual operation needed
+
+<p align="center">
+  <img src="assets/demo_auto-capture-memory.gif" width="720" alt="Auto capture demo: After enabling auto capture, ContextDrop caches conversation memories locally">
+</p>
+
+### ② One-Click Memory Injection — Never Tell Your Story From Scratch Again
+
+Find the relevant memory card, click the "🧠" button on the right, and inject the AI memory into the current conversation with one click — enabling cross-session and cross-platform transfer
+
+<p align="center">
+  <img src="assets/demo_inject-ai-memory.gif" width="720" alt="One-click memory injection demo: Click the '🧠' button on a memory card to inject the memory into the current conversation">
+</p>
+
+### ③ Batch Capture Sessions — Archive in Batches Periodically, No Need to Do It One by One
+
+Click the "Batch Capture" button, and ContextDrop will scan the entire session list, archiving all AI assistant memories with one click
+
+<p align="center">
+  <img src="assets/demo_batch-capture-memory.gif" width="720" alt="Batch capture demo: One-click capture of AI sessions across multiple platforms">
+</p>
+
+---
+
+## Installation
+
+### Step 1: Download the Extension
+
+Go to the [Releases page](https://github.com/Jackie2049/ContextDrop/releases), download the latest version `ContextDrop-*.zip` and extract it to any directory.
+
+### Step 2: Install the Extension
+
+1. Open Chrome or Edge browser, type `chrome://extensions/` (or `edge://extensions/`) in the address bar and press Enter
+2. Enable the **"Developer mode"** toggle in the top right corner
+3. Click the **"Load unpacked"** button in the top left
+4. In the folder picker, select the extracted **ContextDrop** folder
+5. After successful loading, **ContextDrop's icon 🧠** will appear in "All Extensions"
+6. Click the **🧩 "Extensions"** button in the top right of the browser toolbar, then click the pin icon to pin it
+
+### Step 3: Start Using
+
+- Open any AI assistant (e.g., ChatGPT, Claude, DeepSeek, etc.) and start chatting normally
+- The extension will **automatically capture** your conversation records with the AI assistant and save them locally
+- Click the **"🧠"** button in the browser toolbar to view and manage historical sessions
+
+---
+
+## What's New
+
+---
+
+## Supported Platforms
+
+
+| Platform       | Status  | Notes   |
+| -------------- | ------- | ------- |
+| [Doubao](https://www.doubao.com/)       | ✅   | Web AI assistant supported |
+| [Yuanbao](https://yuanbao.tencent.com/)       | ✅   | Web AI assistant supported |
+| [Claude](https://claude.ai/)   | ✅   | Web AI assistant supported |
+| [DeepSeek](https://chat.deepseek.com/) | ✅   | Web AI assistant supported |
+| [Kimi](https://www.kimi.com/)     | ✅   | Web AI assistant supported |
+| [Gemini](https://gemini.google.com/)   | ✅   | Web AI assistant supported |
+| [ChatGPT](https://chatgpt.com/)  | ✅   | Web AI assistant supported |
+
+
+---
+
+## Contributing
+
+Issues and Pull Requests are welcome!
+
+---
+
+## License
+
+MIT License

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@
   <img src="https://img.shields.io/badge/Chrome%20Extension-MV3-green.svg?logo=googlechrome" alt="Chrome Extension MV3">
 </p>
 
+<p align="center">
+  <a href="./README.md">中文</a> | <a href="./README.en.md">English</a>
+</p>
+
 **ContextDrop**是一款专注于**AI助手记忆管理**的浏览器插件。它可以：<br>
 
 💾 **捕获会话**：用户使用AI助手时，插件自动保存用户和AI助手之间的会话记录<br> 


### PR DESCRIPTION
## Summary

- Close #6
- Add English translation of README (README.en.md)

## Changes

- Created `README.en.md` — a 1:1 English translation of the existing Chinese README
- All sections translated including: project introduction, feature demos, installation guide, supported platforms, contributing, and license

## Preview

The English README mirrors the structure and formatting of the original Chinese version, with appropriate localization of platform names and descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)